### PR TITLE
update to req.query for express 4.xx

### DIFF
--- a/lib/activator.js
+++ b/lib/activator.js
@@ -24,7 +24,7 @@ var mailer, templates, emailProperty, idProperty, resetExpire,
  * @param {Object} propertyName - property to get
  */
 function getProperty(req, propertyName) {
-  return req.activator && req.activator[propertyName] || req.param(propertyName);
+  return req.activator && req.activator[propertyName] || req.query[propertyName];
 }
 
 /**

--- a/lib/activator.js
+++ b/lib/activator.js
@@ -24,7 +24,8 @@ var mailer, templates, emailProperty, idProperty, resetExpire,
  * @param {Object} propertyName - property to get
  */
 function getProperty(req, propertyName) {
-  return req.activator && req.activator[propertyName] || req.query[propertyName];
+  return req.activator && req.activator[propertyName] || 
+    req.query[propertyName] || req.body[propertyName] || req.params[propertyName];
 }
 
 /**


### PR DESCRIPTION
removes this warning:

express deprecated req.param(name): Use req.params, req.body, or req.query instead node_modules\express-user-activator\lib\activator.js:27:62

see http://expressjs.com/api.html
