### PR TITLE
Use idProperty in query string.

### DIFF
--- a/lib/mailcomposer.js
+++ b/lib/mailcomposer.js
@@ -12,6 +12,7 @@ var PATH = './templates',
 var INIT_CALLED = false;
 var isProd = process.env.NODE_ENV === 'production';
 var activation_link, passwordreset_link;
+var idProperty = null;
 
 /**
  * Initialize mail composer
@@ -20,7 +21,8 @@ var activation_link, passwordreset_link;
 function initialize(templatePath, config) {
 	PATH = path.resolve(templatePath || PATH);
 	mails = {};
-
+	idProperty = config.idProperty;
+	
 	var domain = config.domain,
 			protocol = config.protocol,
 			pathActivate = config.pathActivate,
@@ -108,8 +110,8 @@ function compileTemplateWithData(type, lang, config, callback) {
 	}
 
 	var link_querystring = 	'?code=' + encodeURIComponent(config.code) +
-													'&email=' + encodeURIComponent(config.email) +
-													'&user=' + encodeURIComponent(config.id);
+					'&email=' + encodeURIComponent(config.email) +
+					'&' + idProperty + '=' encodeURIComponent(config.id);
 
 	// use this reference for allowing people
 	// to override templateGet function if they really

--- a/lib/mailcomposer.js
+++ b/lib/mailcomposer.js
@@ -111,7 +111,7 @@ function compileTemplateWithData(type, lang, config, callback) {
 
 	var link_querystring = 	'?code=' + encodeURIComponent(config.code) +
 					'&email=' + encodeURIComponent(config.email) +
-					'&' + idProperty + '=' encodeURIComponent(config.id);
+					'&' + idProperty + '=' + encodeURIComponent(config.id);
 
 	// use this reference for allowing people
 	// to override templateGet function if they really


### PR DESCRIPTION
If idProperty is customized, the customized value must be used in the link_querystring, as it is used for lookup here:

https://github.com/arkcore/activator/blob/master/lib/activator.js#L115
